### PR TITLE
Update to clap 4 + rework to declarative style

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,25 +189,37 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.22"
+version = "4.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+checksum = "30607dd93c420c6f1f80b544be522a0238a7db35e6a12968d28910983fee0df0"
 dependencies = [
  "atty",
  "bitflags",
+ "clap_derive",
  "clap_lex",
- "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a307492e1a34939f79d3b6b9650bd2b971513cd775436bf2b78defeb5af00b"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -631,6 +643,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,6 +1049,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1424,12 +1466,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
-
-[[package]]
 name = "thiserror"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1601,6 +1637,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1215,7 +1215,7 @@ dependencies = [
 [[package]]
 name = "rust-apt"
 version = "0.4.1"
-source = "git+https://gitlab.com/volian/rust-apt?branch=fix/tagfile-parsing#7750594be3ca30ee29804bf46cf76896dd61655b"
+source = "git+https://gitlab.com/volian/rust-apt#d782cb01814c747c3dde82b23a8d4eac200bbff8"
 dependencies = [
  "cxx",
  "cxx-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["command-line-utilities"]
 bat = { version = "0.21.0", default-features = false, features = ["paging", "regex-fancy"]}
 colored = { git = "https://github.com/mackwic/colored" }
 chrono = "0.4.19"
-clap = { version = "3.2.16", features = ["cargo", "env"] }
+clap = { version = "4", features = ["derive", "env", "cargo"] }
 dirs = "4.0.0"
 edit = "0.1.4"
 exitcode = "1.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ makedeb-srcinfo = "0.8.0"
 quit = "1.1.4"
 regex = "1.6.0"
 reqwest = { version = "0.11.11", features = ["blocking", "json"] }
-rust-apt = { git = "https://gitlab.com/volian/rust-apt", branch = "fix/tagfile-parsing" }
+rust-apt = { git = "https://gitlab.com/volian/rust-apt" }
 serde = { version = "1.0.142", features = ["derive"] }
 serde_json = "1.0.83"
 tempfile = "3.3.0"

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,0 +1,175 @@
+// use std::fmt;
+
+use clap::{Args, Parser, Subcommand, ValueEnum};
+
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+#[command(propagate_version = true)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Subcommand)]
+pub enum Commands {
+    /// Clone a package base from the MPR
+    Clone {
+        /// The package to clone
+        #[arg(required = true)]
+        package_name: String,
+
+        #[command(flatten)]
+        mpr_url: MprURL,
+    },
+    /// Comment on a package page
+    Comment {
+        /// The package to comment on
+        #[arg(required = true)]
+        package_name: String,
+
+        /// The comment to post
+        #[arg(short, long = "msg")]
+        message: Option<String>,
+
+        #[command(flatten)]
+        mpr_url: MprURL,
+
+        #[command(flatten)]
+        mpr_token: MprToken,
+    },
+    /// Install packages from APT and the MPR
+    Install {
+        /// The package(s) to install
+        #[arg(required = true)]
+        package_names: Vec<String>,
+
+        #[command(flatten)]
+        mpr_url: MprURL,
+    },
+    /// List packages available via APT and the MPR
+    List {
+        #[command(flatten)]
+        mpr_url: MprURL,
+
+        /// Output the package's name without any extra details
+        #[arg(long = "name-only", default_value_t = false)]
+        name_only: bool,
+
+        #[arg(long, value_enum, default_value_t=SearchMode::None)]
+        mode: SearchMode,
+
+        /// The package(s) to get information for
+        #[arg(required = true)]
+        package_names: Vec<String>,
+    },
+    /// List the comments on a package
+    ListComments {
+        #[command(flatten)]
+        mpr_url: MprURL,
+
+        /// When to send output to a pager
+        #[arg(long, value_enum, default_value_t=Paging::Auto)]
+        paging: Paging,
+
+        /// The package(s) to get information for
+        #[arg(required = true)]
+        package_name: String,
+    },
+    /// Remove packages from the system
+    Remove {
+        #[command(flatten)]
+        mpr_url: MprURL,
+
+        /// Remove configuration files along with the package(s)
+        #[arg(long)]
+        purge: bool,
+
+        /// Remove configuration files along with the package(s)
+        #[arg(long)]
+        autoremove: bool,
+
+        /// The package(s) to get information for
+        #[arg(required = true)]
+        package_names: Vec<String>,
+    },
+    /// Search for an APT/MPR package
+    Search {
+        #[command(flatten)]
+        mpr_url: MprURL,
+
+        /// Output the package's name without any extra details
+        #[arg(long = "name-only", default_value_t = false)]
+        name_only: bool,
+
+        #[arg(long, value_enum, default_value_t=SearchMode::None)]
+        mode: SearchMode,
+
+        /// The package(s) to get information for
+        #[arg(required = true)]
+        query: Vec<String>,
+    },
+    /// Update the APT cache on the system
+    Update {
+        #[command(flatten)]
+        mpr_url: MprURL,
+    },
+    /// Upgrade the packages on the system
+    Upgrade {
+        #[command(flatten)]
+        mpr_url: MprURL,
+
+        #[arg(long, value_enum, default_value_t=UpgradeMode::Both)]
+        mode: UpgradeMode,
+    },
+    /// Show the currently authenticated user
+    Whoami {
+        #[command(flatten)]
+        mpr_url: MprURL,
+
+        #[command(flatten)]
+        mpr_token: MprToken,
+    },
+}
+
+#[derive(Clone, Debug, ValueEnum)]
+pub enum UpgradeMode {
+    /// Upgrade both APT and MPR packages
+    Both,
+    /// Only upgrade APT packages
+    AptOnly,
+    /// Only upgrade MPR packages
+    MprOnly
+}
+
+#[derive(Clone, Debug, ValueEnum)]
+pub enum Paging {
+    Auto,
+    Always,
+    Never
+}
+
+#[derive(Args)]
+pub struct MprURL {
+    /// URL to access the MPR from
+    #[arg(env = "MPR_URL", default_value = "https://mpr.makedeb.org", long = "mpr-url")]
+    pub url: String,
+}
+
+#[derive(Args)]
+pub struct MprToken {
+    /// The API token to authenticate to the MPR with
+    #[arg(env = "MPR_TOKEN", required = true, hide_env_values = true, long = "token")]
+    pub token: String,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
+pub enum SearchMode {
+    /// No filter applied
+    None,
+    /// Only packages available on the MPR
+    MprOnly,
+    /// Only packages available via APT
+    AptOnly,
+    /// Only installed packages
+    Installed
+}

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,5 +1,3 @@
-// use std::fmt;
-
 use clap::{Args, Parser, Subcommand, ValueEnum};
 
 #[derive(Parser)]

--- a/src/clone.rs
+++ b/src/clone.rs
@@ -4,9 +4,7 @@ use crate::{
 };
 use rust_apt::cache::Cache as AptCache;
 
-pub fn clone(args: &clap::ArgMatches) {
-    let pkg: &String = args.get_one("pkg").unwrap();
-    let mpr_url: &String = args.get_one("mpr-url").unwrap();
+pub fn clone(pkg: &String, mpr_url: &String) {
     let cache = Cache::new(AptCache::new(), MprCache::new());
     let mut pkgbases: Vec<&String> = Vec::new();
 

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -9,17 +9,7 @@ struct CommentResult {
     link: String,
 }
 
-pub fn comment(args: &clap::ArgMatches) {
-    let pkg: &String = args.get_one("pkg").unwrap();
-    let mpr_url: &String = args.get_one("mpr-url").unwrap();
-    let api_token: &String = match args.get_one("token") {
-        Some(token) => token,
-        None => {
-            message::error("No API token was provided.\n");
-            quit::with_code(exitcode::USAGE);
-        }
-    };
-
+pub fn comment(pkg: &String, message: &Option<String>, api_token: String, mpr_url: String) {
     // Get a list of packages.
     let mpr_cache = MprCache::new();
     let mut pkgnames: Vec<&String> = Vec::new();
@@ -36,7 +26,7 @@ pub fn comment(args: &clap::ArgMatches) {
 
     // Get the message.
     // If no message was supplied, get one from the user.
-    let msg: String = match args.get_one::<String>("msg") {
+    let msg: String = match message {
         Some(msg) => (msg).to_owned(),
         None => {
             // Get the editor.

--- a/src/install.rs
+++ b/src/install.rs
@@ -6,9 +6,7 @@ use crate::{
 };
 use rust_apt::cache::Cache as AptCache;
 
-pub fn install(args: &clap::ArgMatches) {
-    let pkglist: Vec<&String> = args.get_many("pkg").unwrap().collect();
-    let mpr_url: &String = args.get_one("mpr-url").unwrap();
+pub fn install(pkglist: &Vec<String>,  mpr_url: String) {
     let cache = Cache::new(AptCache::new(), MprCache::new());
 
     // Package sources.
@@ -20,7 +18,7 @@ pub fn install(args: &clap::ArgMatches) {
     // should just show those packages and abort.
     let mut unfindable = false;
 
-    for pkg in &pkglist {
+    for pkg in pkglist {
         if cache.get_apt_pkg(pkg).is_none() && cache.get_mpr_pkg(pkg).is_none() {
             message::error(&format!(
                 "Unable to find package '{}'.\n",
@@ -34,7 +32,7 @@ pub fn install(args: &clap::ArgMatches) {
         quit::with_code(exitcode::USAGE);
     }
 
-    for pkg in &pkglist {
+    for pkg in pkglist {
         let apt_pkg = cache.get_apt_pkg(pkg);
         let mpr_pkg = cache.get_mpr_pkg(pkg);
 
@@ -80,5 +78,5 @@ pub fn install(args: &clap::ArgMatches) {
         quit::with_code(exitcode::UNAVAILABLE);
     }
 
-    cache.commit(&mpr_install_order, mpr_url);
+    cache.commit(&mpr_install_order, &mpr_url);
 }

--- a/src/list.rs
+++ b/src/list.rs
@@ -1,19 +1,11 @@
 use crate::{
+    args::SearchMode,
     cache::{Cache, CachePackage, MprCache},
     style,
 };
 use rust_apt::cache::Cache as AptCache;
 
-pub fn list(args: &clap::ArgMatches) {
-    let pkglist: Vec<&String> = match args.get_many("pkg") {
-        Some(pkglist) => pkglist.collect(),
-        None => Vec::new(),
-    };
-    let apt_only = args.is_present("apt-only");
-    let mpr_only = args.is_present("mpr-only");
-    let installed_only = args.is_present("installed-only");
-    let name_only = args.is_present("name-only");
-
+pub fn list(pkglist: &Vec<String>, _: &String, mode: &SearchMode, name_only: &bool) {
     let cache = Cache::new(AptCache::new(), MprCache::new());
     let mut candidates: Vec<&Vec<CachePackage>> = Vec::new();
 
@@ -34,10 +26,8 @@ pub fn list(args: &clap::ArgMatches) {
         style::generate_pkginfo_entries(
             &candidates,
             &cache,
-            apt_only,
-            mpr_only,
-            installed_only,
-            name_only
+            mode,
+            *name_only
         )
     );
 }

--- a/src/list_comments.rs
+++ b/src/list_comments.rs
@@ -1,4 +1,4 @@
-use crate::{cache::MprCache, message};
+use crate::{cache::MprCache, message, args::Paging};
 use bat::{self, PrettyPrinter};
 use chrono::{TimeZone, Utc};
 use serde::Deserialize;
@@ -11,10 +11,7 @@ struct Comment {
     user: String,
 }
 
-pub fn list_comments(args: &clap::ArgMatches) {
-    let pkgbase: &String = args.get_one("pkg").unwrap();
-    let mpr_url: &String = args.get_one("mpr-url").unwrap();
-    let paging = args.get_one::<String>("paging").unwrap().as_str();
+pub fn list_comments(pkgbase: &String, mpr_url: &String, paging: &Paging) {
     let mpr_cache = MprCache::new();
 
     let mut pkgbases: Vec<&String> = Vec::new();
@@ -77,9 +74,9 @@ pub fn list_comments(args: &clap::ArgMatches) {
 
     // Get the paging mode from the user.
     let paging_mode = match paging {
-        "always" => bat::PagingMode::Always,
-        "never" => bat::PagingMode::Never,
-        &_ => bat::PagingMode::QuitIfOneScreen,
+        Paging::Always => bat::PagingMode::Always,
+        Paging::Never => bat::PagingMode::Never,
+        Paging::Auto => bat::PagingMode::QuitIfOneScreen,
     };
 
     PrettyPrinter::new()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 #![feature(let_chains)]
+mod args;
 mod cache;
 mod clone;
 mod comment;
@@ -16,7 +17,8 @@ mod upgrade;
 mod util;
 mod whoami;
 
-use clap::{self, Arg, Command, PossibleValue};
+use args::{Cli, Commands};
+use clap::Parser;
 pub use rust_apt::util as apt_util;
 use std::{
     env,
@@ -26,183 +28,8 @@ use std::{
 use style::Colorize;
 use which::which;
 
-#[rustfmt::skip]
-fn get_cli() -> Command<'static> {
-    // Common arguments used in multiple commands.
-    let token_arg = Arg::new("token")
-        .help("The API token to authenticate to the MPR with")
-        .long("token")
-        .env("MPR_TOKEN")
-        .hide_env_values(true)
-        .takes_value(true)
-        .required(true);
-
-    let mpr_url_arg = Arg::new("mpr-url")
-        .help("URL to access the MPR from")
-        .long("mpr-url")
-        .env("MPR_URL")
-        .hide_env_values(true)
-        .takes_value(true)
-        .default_value("https://mpr.makedeb.org");
-
-    let mpr_only_arg = Arg::new("mpr-only")
-        .help("Filter results to packages available on the MPR")
-        .long("mpr-only");
-    
-    let apt_only_arg = Arg::new("apt-only")
-        .help("Filter results to packages available via APT")
-        .long("apt-only");
-
-    let installed_only_arg = Arg::new("installed-only")
-        .help("Filter results to installed packages")
-        .short('i')
-        .long("installed");
-    
-    let name_only_arg = Arg::new("name-only")
-        .help("Output the package's name without any extra details")
-        .long("name-only");
-
-    // The CLI.
-    Command::new(clap::crate_name!())
-        .version(clap::crate_version!())
-        .about(clap::crate_description!())
-        .arg_required_else_help(true)
-        .subcommand(
-            Command::new("clone")
-                .about("Clone a package base from the MPR")
-                .arg(
-                    Arg::new("pkg")
-                        .help("The package to clone")
-                        .required(true)
-                )
-                .arg(mpr_url_arg.clone())
-        )
-        .subcommand(
-            Command::new("comment")
-                .arg_required_else_help(true)
-                .about("Comment on a package page")
-                .arg(
-                    Arg::new("pkg")
-                        .help("The package to comment on")
-                        .required(true)
-                        .takes_value(true)
-                )
-                .arg(
-                    Arg::new("msg")
-                        .help("The comment to post")
-                        .short('m')
-                        .long("msg")
-                )
-                .arg(token_arg.clone())
-                .arg(mpr_url_arg.clone())
-        )
-        .subcommand(
-            Command::new("install")
-            .about("Install packages from APT and the MPR")
-            .arg(
-                Arg::new("pkg")
-                .help("The package(s) to install")
-                .multiple_values(true)
-                .required(true)
-            )
-            .arg(mpr_url_arg.clone())
-        )
-        .subcommand(
-            Command::new("list")
-            .about("List packages available via APT and the MPR")
-            .arg(
-                Arg::new("pkg")
-                .help("The package(s) to get information for")
-                .multiple_values(true)
-            )
-            .arg(mpr_only_arg.clone())
-            .arg(apt_only_arg.clone())
-            .arg(installed_only_arg.clone())
-            .arg(name_only_arg.clone())
-        )
-        .subcommand(
-            Command::new("list-comments")
-                .arg_required_else_help(true)
-                .about("List the comments on a package")
-                .arg(
-                    Arg::new("pkg")
-                        .help("The package to view comments for")
-                        .required(true)
-                )
-                .arg(
-                    Arg::new("paging")
-                        .help("When to send output to a pager")
-                        .long("paging")
-                        .takes_value(true)
-                        .default_value("auto")
-                        .value_parser([
-                            PossibleValue::new("auto"),
-                            PossibleValue::new("always"),
-                            PossibleValue::new("never")
-                        ])
-                )
-                .arg(mpr_url_arg.clone())
-        )
-        .subcommand(
-            Command::new("remove")
-                .about("Remove packages from the system")
-                .arg_required_else_help(true)
-                .arg(
-                    Arg::new("pkg")
-                        .help("The package(s) to remove")
-                        .multiple_values(true)
-                )
-                .arg(
-                    Arg::new("purge")
-                        .help("Remove configuration files along with the package(s)")
-                        .long("purge")
-                )
-                .arg(
-                    Arg::new("autoremove")
-                        .help("Automatically remove any unneeded packages")
-                        .long("autoremove")
-                )
-                .arg(mpr_url_arg.clone().hide(true))
-        )
-        .subcommand(
-            Command::new("search")
-                .about("Search for an APT/MPR package")
-                .arg_required_else_help(true)
-                .arg(
-                    Arg::new("query")
-                        .required(true)
-                        .help("The query to search for")
-                        .multiple_values(true)
-                )
-                .arg(mpr_only_arg.clone())
-                .arg(apt_only_arg.clone())
-                .arg(installed_only_arg.clone())
-                .arg(name_only_arg.clone())
-        )
-        .subcommand(
-            Command::new("update")
-                .about("Update the APT cache on the system")
-                .arg(mpr_url_arg.clone())
-        )
-        .subcommand(
-            Command::new("upgrade")
-                .about("Upgrade the packages on the system")
-                .arg(Arg::new("apt-only").help("Only upgrade APT packages").long("apt-only").conflicts_with("mpr-only"))
-                .arg(Arg::new("mpr-only").help("Only upgrade MPR packages").long("mpr-only").conflicts_with("apt-only"))
-                .arg(mpr_url_arg.clone())
-        )
-        .subcommand(
-            Command::new("whoami")
-                .about("Show the currently authenticated user")
-                .arg(token_arg.clone())
-                .arg(mpr_url_arg.clone())
-        )
-}
-
 #[quit::main]
 fn main() {
-    let cmd_results = get_cli().get_matches();
-
     // Make sure that this executable has the `setuid` flag set and is owned by
     // root. Parts of this program (intentionally) expect such behavior.
     let cmd_name = {
@@ -239,35 +66,66 @@ fn main() {
 
     util::sudo::to_root();
 
-    // If we're running a command that should be permission-checked, then do so.
-    if vec!["install", "remove", "update", "upgrade"].contains(&cmd_results.subcommand().unwrap().0)
-    {
-        // If we're running a command that invokes 'makedeb', ensure that we're not
-        // running as root.
-        if vec!["install", "upgrade"].contains(&cmd_results.subcommand().unwrap().0)
-            && *util::sudo::NORMAL_UID == 0
-        {
-            message::error(&format!(
-            "This command cannot be ran as root, as it needs to call '{}', which is required to run under a non-root user.\n",
-            "makedeb".bold().green()
-        ));
-            quit::with_code(exitcode::USAGE);
-        }
+    let cli = Cli::parse();
 
-        util::sudo::check_perms();
-    }
+    match &cli.command {
+        Commands::Clone { package_name, mpr_url } => {
+            println!("'clone' {:?} from {:?}", package_name, mpr_url.url);
+            clone::clone(package_name, &mpr_url.url)
+        },
+        Commands::Comment { package_name, message, mpr_url, mpr_token } => {
+            println!("'comment': package {:?}: '{:?}'. Token: '{:?}' on {:?}", package_name, message, mpr_token.token, mpr_url.url);
+            comment::comment(package_name, message, mpr_token.token.clone(), mpr_url.url.clone())
+        },
+        Commands::Install { package_names, mpr_url } => {
+            println!("'install': packages {:?}: on {:?}", package_names, mpr_url.url);
 
-    match cmd_results.subcommand() {
-        Some(("clone", args)) => clone::clone(args),
-        Some(("comment", args)) => comment::comment(args),
-        Some(("install", args)) => install::install(args),
-        Some(("list", args)) => list::list(args),
-        Some(("list-comments", args)) => list_comments::list_comments(args),
-        Some(("remove", args)) => remove::remove(args),
-        Some(("search", args)) => search::search(args),
-        Some(("update", args)) => update::update(args),
-        Some(("upgrade", args)) => upgrade::upgrade(args),
-        Some(("whoami", args)) => whoami::whoami(args),
-        _ => unreachable!(),
+            if *util::sudo::NORMAL_UID == 0 {
+                return message::error(&format!(
+                    "This command cannot be ran as root, as it needs to call '{}', which is required to run under a non-root user.\n",
+                    "makedeb".bold().green()
+                ));
+            }
+
+            install::install(package_names, mpr_url.url.clone())
+        },
+        Commands::List { package_names, mode, mpr_url, name_only } => {
+            println!("'list': packages {:?}: on {:?}. filter mode: {:?}, name_only: {}", package_names, mpr_url.url, mode, name_only);
+            list::list(package_names, &mpr_url.url, mode, name_only)
+        },
+        Commands::ListComments { package_name, mpr_url, paging } => {
+            println!("'list comments': package {:?}: on {:?}. paging mode: {:?}", package_name, mpr_url.url, paging);
+            list_comments::list_comments(package_name, &mpr_url.url, paging)
+        },
+        Commands::Remove { package_names, mpr_url, purge, autoremove } => {
+            println!("'remove': packages {:?}: on {:?}. purge: {}, autoremove: {}", package_names, mpr_url.url, purge, autoremove);
+            util::sudo::check_perms();
+            remove::remove(package_names, &mpr_url.url, *purge, *autoremove)
+        },
+        Commands::Search { query, mode, mpr_url, name_only } => {
+            println!("'search': query {:?}: on {:?}. filter mode: {:?}, name_only: {}", query, mpr_url.url, mode, name_only);
+            search::search(query, &mpr_url.url, mode, *name_only)
+        },
+        Commands::Update { mpr_url } => {
+            println!("'update': on {:?}", mpr_url.url);
+            util::sudo::check_perms();
+            update::update(&mpr_url.url)
+        },
+        Commands::Upgrade { mpr_url, mode } => {
+            println!("'upgrade': on {:?}, mode: {:?}", mpr_url.url, mode);
+
+            if *util::sudo::NORMAL_UID == 0 {
+                return message::error(&format!(
+                    "This command cannot be ran as root, as it needs to call '{}', which is required to run under a non-root user.\n",
+                    "makedeb".bold().green()
+                ));
+            }
+
+            upgrade::upgrade(&mpr_url.url, mode)
+        },
+        Commands::Whoami { mpr_url, mpr_token } => {
+            println!("'whoami': Token '{:?}' on {:?}", mpr_token.token, mpr_url.url);
+            whoami::whoami(mpr_token.token.clone(), mpr_url.url.clone())
+        },
     };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,16 +70,12 @@ fn main() {
 
     match &cli.command {
         Commands::Clone { package_name, mpr_url } => {
-            println!("'clone' {:?} from {:?}", package_name, mpr_url.url);
             clone::clone(package_name, &mpr_url.url)
         },
         Commands::Comment { package_name, message, mpr_url, mpr_token } => {
-            println!("'comment': package {:?}: '{:?}'. Token: '{:?}' on {:?}", package_name, message, mpr_token.token, mpr_url.url);
             comment::comment(package_name, message, mpr_token.token.clone(), mpr_url.url.clone())
         },
         Commands::Install { package_names, mpr_url } => {
-            println!("'install': packages {:?}: on {:?}", package_names, mpr_url.url);
-
             if *util::sudo::NORMAL_UID == 0 {
                 return message::error(&format!(
                     "This command cannot be ran as root, as it needs to call '{}', which is required to run under a non-root user.\n",
@@ -90,30 +86,23 @@ fn main() {
             install::install(package_names, mpr_url.url.clone())
         },
         Commands::List { package_names, mode, mpr_url, name_only } => {
-            println!("'list': packages {:?}: on {:?}. filter mode: {:?}, name_only: {}", package_names, mpr_url.url, mode, name_only);
             list::list(package_names, &mpr_url.url, mode, name_only)
         },
         Commands::ListComments { package_name, mpr_url, paging } => {
-            println!("'list comments': package {:?}: on {:?}. paging mode: {:?}", package_name, mpr_url.url, paging);
             list_comments::list_comments(package_name, &mpr_url.url, paging)
         },
         Commands::Remove { package_names, mpr_url, purge, autoremove } => {
-            println!("'remove': packages {:?}: on {:?}. purge: {}, autoremove: {}", package_names, mpr_url.url, purge, autoremove);
             util::sudo::check_perms();
             remove::remove(package_names, &mpr_url.url, *purge, *autoremove)
         },
         Commands::Search { query, mode, mpr_url, name_only } => {
-            println!("'search': query {:?}: on {:?}. filter mode: {:?}, name_only: {}", query, mpr_url.url, mode, name_only);
             search::search(query, &mpr_url.url, mode, *name_only)
         },
         Commands::Update { mpr_url } => {
-            println!("'update': on {:?}", mpr_url.url);
             util::sudo::check_perms();
             update::update(&mpr_url.url)
         },
         Commands::Upgrade { mpr_url, mode } => {
-            println!("'upgrade': on {:?}, mode: {:?}", mpr_url.url, mode);
-
             if *util::sudo::NORMAL_UID == 0 {
                 return message::error(&format!(
                     "This command cannot be ran as root, as it needs to call '{}', which is required to run under a non-root user.\n",
@@ -124,7 +113,6 @@ fn main() {
             upgrade::upgrade(&mpr_url.url, mode)
         },
         Commands::Whoami { mpr_url, mpr_token } => {
-            println!("'whoami': Token '{:?}' on {:?}", mpr_token.token, mpr_url.url);
             whoami::whoami(mpr_token.token.clone(), mpr_url.url.clone())
         },
     };

--- a/src/remove.rs
+++ b/src/remove.rs
@@ -5,17 +5,7 @@ use crate::{
 };
 use rust_apt::cache::{Cache as AptCache, PackageSort};
 
-pub fn remove(args: &clap::ArgMatches) {
-    let pkglist: Vec<&String> = {
-        if let Some(pkglist) = args.get_many("pkg") {
-            pkglist.collect()
-        } else {
-            Vec::new()
-        }
-    };
-    let purge = args.is_present("purge");
-    let autoremove = args.is_present("autoremove");
-    let mpr_url: &String = args.get_one("mpr-url").unwrap();
+pub fn remove(pkglist: &Vec<String>, mpr_url: &String, purge: bool, autoremove: bool) {
     let cache = Cache::new(AptCache::new(), MprCache::new());
 
     // Lock the cache.

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,16 +1,11 @@
 use crate::{
     cache::{Cache, CachePackage, MprCache},
+    args::SearchMode,
     style,
 };
 use rust_apt::cache::Cache as AptCache;
 
-pub fn search(args: &clap::ArgMatches) {
-    let query_list: Vec<&String> = args.get_many("query").unwrap().collect();
-    let apt_only = args.is_present("apt-only");
-    let mpr_only = args.is_present("mpr-only");
-    let installed_only = args.is_present("installed-only");
-    let name_only = args.is_present("name-only");
-
+pub fn search(query_list: &Vec<String>, _: &String, mode: &SearchMode, name_only: bool) {
     let cache = Cache::new(AptCache::new(), MprCache::new());
     let mut candidates: Vec<&Vec<CachePackage>> = Vec::new();
 
@@ -47,9 +42,7 @@ pub fn search(args: &clap::ArgMatches) {
         style::generate_pkginfo_entries(
             &candidates,
             &cache,
-            apt_only,
-            mpr_only,
-            installed_only,
+            mode,
             name_only
         )
     );

--- a/src/update.rs
+++ b/src/update.rs
@@ -8,9 +8,7 @@ use std::{
     process::Command,
 };
 
-pub fn update(args: &clap::ArgMatches) {
-    let mpr_url: &String = args.get_one("mpr-url").unwrap();
-
+pub fn update(mpr_url: &String) {
     // For some reason we have to set our current UID to 0 instead of just the EUID
     // when using setuid functionality. TODO: No clue why, but this fixes the
     // issue for now.

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -1,4 +1,5 @@
 use crate::{
+    args::UpgradeMode,
     cache::{Cache, MprCache},
     install_util, util,
 };
@@ -8,10 +9,12 @@ use rust_apt::{
 };
 use std::{collections::HashMap, fs};
 
-pub fn upgrade(args: &clap::ArgMatches) {
-    let apt_only = args.is_present("apt-only");
-    let mpr_only = args.is_present("mpr-only");
-    let mpr_url: &String = args.get_one("mpr-url").unwrap();
+pub fn upgrade(mpr_url: &String, upgrade_mode: &UpgradeMode) {
+    let (apt_only, mpr_only) = match upgrade_mode {
+        UpgradeMode::Both => (false, false),
+        UpgradeMode::AptOnly => (true, false),
+        UpgradeMode::MprOnly => (false, true),
+    };
 
     let cache = Cache::new(AptCache::new(), MprCache::new());
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -20,13 +20,13 @@ struct AuthenticationError {
 }
 
 // Struct to handle API-authenticated requests to the MPR.
-pub struct AuthenticatedRequest<'a> {
-    api_token: &'a str,
-    mpr_url: &'a str,
+pub struct AuthenticatedRequest {
+    api_token: String,
+    mpr_url: String,
 }
 
-impl<'a> AuthenticatedRequest<'a> {
-    pub fn new(api_token: &'a str, mpr_url: &'a str) -> Self {
+impl AuthenticatedRequest {
+    pub fn new(api_token: String, mpr_url: String) -> Self {
         Self { api_token, mpr_url }
     }
 
@@ -60,7 +60,7 @@ impl<'a> AuthenticatedRequest<'a> {
         let client = reqwest::blocking::Client::new();
         let resp = client
             .get(format!("{}/api/{}", self.mpr_url, path))
-            .header("Authorization", self.api_token)
+            .header("Authorization", &self.api_token)
             .send();
 
         self.handle_response(resp)
@@ -72,7 +72,7 @@ impl<'a> AuthenticatedRequest<'a> {
         let resp = client
             .post(format!("{}/api/{}", self.mpr_url, path))
             .body(body)
-            .header("Authorization", self.api_token)
+            .header("Authorization", &self.api_token)
             .send();
 
         self.handle_response(resp)

--- a/src/whoami.rs
+++ b/src/whoami.rs
@@ -1,4 +1,4 @@
-use crate::{message, util};
+use crate::{util};
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -6,16 +6,7 @@ struct Authenticated {
     user: String,
 }
 
-pub fn whoami(args: &clap::ArgMatches) {
-    let api_token: &String = match args.get_one("token") {
-        Some(token) => token,
-        None => {
-            message::error("No API key was provided.");
-            quit::with_code(exitcode::USAGE);
-        }
-    };
-    let mpr_url: &String = args.get_one("mpr-url").unwrap();
-
+pub fn whoami(api_token: String, mpr_url: String) {
     let request = util::AuthenticatedRequest::new(api_token, mpr_url);
     let resp_text = request.get("test");
     let json = serde_json::from_str::<Authenticated>(&resp_text).unwrap();


### PR DESCRIPTION
And here's something no-one asked for but i was interested in: Clap 4!

Saw recent `clap` release, also never had a chance to try it, so i decided to give it a go.

I think declarative style is easier to read(and args parsing is more explicit). Also i took some liberties with `search` and `list` args for filtering, turning them into `discriminated union`(since they are mutually exclusive).

This changes the interface a bit, but i though about it as a suggestion - i'll change it back to the way it works now, if you think it's not worth it.

As for the rest of the changes - same story, feel free to reject it if you don't need or like it, it was mostly done as a personal excercise :)