### PR TITLE
Convert to clap (4.x) derive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,25 +189,37 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.23"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+checksum = "335867764ed2de42325fafe6d18b8af74ba97ee0c590fa016f157535b42ab04b"
 dependencies = [
  "atty",
  "bitflags",
+ "clap_derive",
  "clap_lex",
- "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16a1b0f6422af32d5da0c58e2703320f379216ee70198241c84173a8c5ac28f3"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -631,6 +643,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1042,6 +1060,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1435,12 +1477,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
-
-[[package]]
 name = "thiserror"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1612,6 +1648,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["command-line-utilities"]
 bat = { version = "0.21.0", default-features = false, features = ["paging", "regex-fancy"]}
 colored = { git = "https://github.com/mackwic/colored" }
 chrono = "0.4.19"
-clap = { version = "3.2.16", features = ["cargo", "env"] }
+clap = { version = "4.0.18", features = ["cargo", "env", "derive"] }
 dirs = "4.0.0"
 edit = "0.1.4"
 exitcode = "1.1.2"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,157 @@
+use clap::{Parser, ValueEnum};
+
+#[derive(Debug, Clone, ValueEnum)]
+pub enum CliPaging {
+    /// auto
+    Auto,
+    /// always
+    Always,
+    /// never
+    Never,
+}
+
+#[derive(Debug, Parser)]
+#[command(author, version, about)]
+pub struct Cli {
+    /// The API token to authenticate to the MPR with
+    #[clap(long, env = "MPR_TOKEN", hide_env_values = true)]
+    pub token: Option<String>,
+
+    /// URL to access the MPR from
+    #[clap(
+        long,
+        env = "MPR_URL",
+        hide_env_values = true,
+        default_value = "https://mpr.makedeb.org"
+    )]
+    pub mpr_url: String,
+
+    /// Filter results to packages available on the MPR
+    #[arg(long, default_value_t = false, conflicts_with = "apt_only")]
+    pub mpr_only: bool,
+
+    /// Filter results to packages available via APT
+    #[arg(long, default_value_t = false, conflicts_with = "mpr_only")]
+    pub apt_only: bool,
+
+    /// Filter results to installed packages
+    #[clap(long, short = 'i')]
+    #[arg(default_value_t = false)]
+    pub installed_only: bool,
+
+    /// Output the package's name without any extra details
+    #[clap(long, default_value = "false")]
+    pub name_only: bool,
+
+    #[clap(subcommand)]
+    pub subcommand: CliSubcommand,
+}
+
+#[derive(Debug, Parser)]
+pub enum CliSubcommand {
+    /// Clone a package base from the MPR
+    Clone(CliClone),
+
+    /// Comment on a package page
+    Comment(CliComment),
+
+    /// Install packages from APT and the MPR
+    Install(CliInstall),
+
+    /// List packages available via APT and the MPR
+    List(CliList),
+
+    /// List the comments on a package
+    ListComments(CliListComments),
+
+    /// Remove packages from the system
+    Remove(CliRemove),
+
+    /// Search for an APT/MPR package
+    Search(CliSearch),
+
+    /// Update the APT cache on the system
+    Update(CliUpdate),
+
+    /// Upgrade the packages on the system
+    Upgrade(CliUpgrade),
+
+    /// Show the currently authenticated user
+    Whoami(CliWhoami),
+}
+
+#[derive(Debug, Parser)]
+pub struct CliClone {
+    /// The package to clone
+    #[clap(required = true)]
+    pub pkg: String,
+}
+
+#[derive(Debug, Parser)]
+pub struct CliComment {
+    /// The package to comment on
+    #[clap(required = true)]
+    pub pkg: String,
+
+    /// The comment to post
+    #[clap(long, short)]
+    pub msg: Option<String>,
+}
+
+#[derive(Debug, Parser)]
+pub struct CliInstall {
+    /// The package(s) to install
+    #[clap(required = true)]
+    pub pkg: Vec<String>,
+}
+
+#[derive(Debug, Parser)]
+pub struct CliList {
+    /// The package(s) to get information for
+    pub pkg: Vec<String>,
+}
+
+#[derive(Debug, Parser)]
+pub struct CliListComments {
+    /// The package to view comments for
+    #[clap(required = true)]
+    pub pkg: String,
+
+    /// When to send output to a pager
+    #[clap(long)]
+    #[arg(value_enum, default_value_t = CliPaging::Auto)]
+    pub paging: CliPaging,
+}
+
+#[derive(Debug, Parser)]
+pub struct CliRemove {
+    /// The package(s) to remove
+    #[clap(required = true)]
+    pub pkg: Vec<String>,
+
+    /// Remove configuration files along with the package(s)
+    #[clap(long)]
+    #[arg(default_value_t = false)]
+    pub purge: bool,
+
+    /// Automatically remove any unneeded packages
+    #[clap(long)]
+    #[arg(default_value_t = false)]
+    pub autoremove: bool,
+}
+
+#[derive(Debug, Parser)]
+pub struct CliSearch {
+    /// The query to search for
+    #[clap(required = true)]
+    pub query: Vec<String>,
+}
+
+#[derive(Debug, Parser)]
+pub struct CliUpdate {}
+
+#[derive(Debug, Parser)]
+pub struct CliUpgrade {}
+
+#[derive(Debug, Parser)]
+pub struct CliWhoami {}

--- a/src/clone.rs
+++ b/src/clone.rs
@@ -1,12 +1,13 @@
 use crate::{
     cache::{Cache, MprCache},
+    cli::{Cli, CliClone},
     message, util,
 };
 use rust_apt::cache::Cache as AptCache;
 
-pub fn clone(args: &clap::ArgMatches) {
-    let pkg: &String = args.get_one("pkg").unwrap();
-    let mpr_url: &String = args.get_one("mpr-url").unwrap();
+pub fn clone(args: &Cli, cmd_args: &CliClone) {
+    let pkg = &cmd_args.pkg;
+    let mpr_url = &args.mpr_url;
     let cache = Cache::new(AptCache::new(), MprCache::new());
     let mut pkgbases: Vec<&String> = Vec::new();
 

--- a/src/comment.rs
+++ b/src/comment.rs
@@ -1,3 +1,4 @@
+use crate::cli::{Cli, CliComment};
 use crate::{cache::MprCache, message, util};
 use serde::Deserialize;
 use serde_json::json;
@@ -9,10 +10,10 @@ struct CommentResult {
     link: String,
 }
 
-pub fn comment(args: &clap::ArgMatches) {
-    let pkg: &String = args.get_one("pkg").unwrap();
-    let mpr_url: &String = args.get_one("mpr-url").unwrap();
-    let api_token: &String = match args.get_one("token") {
+pub fn comment(args: &Cli, cmd_args: &CliComment) {
+    let pkg = &cmd_args.pkg;
+    let mpr_url = &args.mpr_url;
+    let api_token = match &args.token {
         Some(token) => token,
         None => {
             message::error("No API token was provided.\n");
@@ -36,8 +37,8 @@ pub fn comment(args: &clap::ArgMatches) {
 
     // Get the message.
     // If no message was supplied, get one from the user.
-    let msg: String = match args.get_one::<String>("msg") {
-        Some(msg) => (msg).to_owned(),
+    let msg: String = match &cmd_args.msg {
+        Some(msg) => msg.to_owned(),
         None => {
             // Get the editor.
             let editor = match edit::get_editor() {

--- a/src/list.rs
+++ b/src/list.rs
@@ -1,18 +1,16 @@
 use crate::{
     cache::{Cache, MprCache},
+    cli::{Cli, CliList},
     style,
 };
 use rust_apt::cache::{Cache as AptCache, PackageSort};
 
-pub fn list(args: &clap::ArgMatches) {
-    let pkglist: Vec<&String> = match args.get_many("pkg") {
-        Some(pkglist) => pkglist.collect(),
-        None => Vec::new(),
-    };
-    let apt_only = args.is_present("apt-only");
-    let mpr_only = args.is_present("mpr-only");
-    let installed_only = args.is_present("installed-only");
-    let name_only = args.is_present("name-only");
+pub fn list(args: &Cli, cmd_args: &CliList) {
+    let pkglist = &cmd_args.pkg;
+    let apt_only = args.apt_only;
+    let mpr_only = args.mpr_only;
+    let installed_only = args.installed_only;
+    let name_only = args.name_only;
 
     let cache = Cache::new(AptCache::new(), MprCache::new());
     let mut candidates = Vec::new();

--- a/src/list_comments.rs
+++ b/src/list_comments.rs
@@ -1,4 +1,8 @@
-use crate::{cache::MprCache, message};
+use crate::{
+    cache::MprCache,
+    cli::{Cli, CliListComments},
+    message,
+};
 use bat::{self, PrettyPrinter};
 use chrono::{TimeZone, Utc};
 use serde::Deserialize;
@@ -11,10 +15,10 @@ struct Comment {
     user: String,
 }
 
-pub fn list_comments(args: &clap::ArgMatches) {
-    let pkgbase: &String = args.get_one("pkg").unwrap();
-    let mpr_url: &String = args.get_one("mpr-url").unwrap();
-    let paging = args.get_one::<String>("paging").unwrap().as_str();
+pub fn list_comments(args: &Cli, cmd_args: &CliListComments) {
+    let pkgbase = &cmd_args.pkg;
+    let mpr_url = &args.mpr_url;
+    let paging = &cmd_args.paging;
     let mpr_cache = MprCache::new();
 
     let mut pkgbases: Vec<&String> = Vec::new();
@@ -76,10 +80,11 @@ pub fn list_comments(args: &clap::ArgMatches) {
     }
 
     // Get the paging mode from the user.
+    use crate::cli::CliPaging::*;
     let paging_mode = match paging {
-        "always" => bat::PagingMode::Always,
-        "never" => bat::PagingMode::Never,
-        &_ => bat::PagingMode::QuitIfOneScreen,
+        Auto => bat::PagingMode::QuitIfOneScreen,
+        Always => bat::PagingMode::Always,
+        Never => bat::PagingMode::Never,
     };
 
     PrettyPrinter::new()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #![feature(let_chains)]
 mod cache;
+mod cli;
 mod clone;
 mod comment;
 mod install;
@@ -16,7 +17,6 @@ mod upgrade;
 mod util;
 mod whoami;
 
-use clap::{self, Arg, Command, PossibleValue};
 pub use rust_apt::util as apt_util;
 use std::{
     env,
@@ -26,182 +26,10 @@ use std::{
 use style::Colorize;
 use which::which;
 
-#[rustfmt::skip]
-fn get_cli() -> Command<'static> {
-    // Common arguments used in multiple commands.
-    let token_arg = Arg::new("token")
-        .help("The API token to authenticate to the MPR with")
-        .long("token")
-        .env("MPR_TOKEN")
-        .hide_env_values(true)
-        .takes_value(true)
-        .required(true);
-
-    let mpr_url_arg = Arg::new("mpr-url")
-        .help("URL to access the MPR from")
-        .long("mpr-url")
-        .env("MPR_URL")
-        .hide_env_values(true)
-        .takes_value(true)
-        .default_value("https://mpr.makedeb.org");
-
-    let mpr_only_arg = Arg::new("mpr-only")
-        .help("Filter results to packages available on the MPR")
-        .long("mpr-only");
-    
-    let apt_only_arg = Arg::new("apt-only")
-        .help("Filter results to packages available via APT")
-        .long("apt-only");
-
-    let installed_only_arg = Arg::new("installed-only")
-        .help("Filter results to installed packages")
-        .short('i')
-        .long("installed");
-    
-    let name_only_arg = Arg::new("name-only")
-        .help("Output the package's name without any extra details")
-        .long("name-only");
-
-    // The CLI.
-    Command::new(clap::crate_name!())
-        .version(clap::crate_version!())
-        .about(clap::crate_description!())
-        .arg_required_else_help(true)
-        .subcommand(
-            Command::new("clone")
-                .about("Clone a package base from the MPR")
-                .arg(
-                    Arg::new("pkg")
-                        .help("The package to clone")
-                        .required(true)
-                )
-                .arg(mpr_url_arg.clone())
-        )
-        .subcommand(
-            Command::new("comment")
-                .arg_required_else_help(true)
-                .about("Comment on a package page")
-                .arg(
-                    Arg::new("pkg")
-                        .help("The package to comment on")
-                        .required(true)
-                        .takes_value(true)
-                )
-                .arg(
-                    Arg::new("msg")
-                        .help("The comment to post")
-                        .short('m')
-                        .long("msg")
-                )
-                .arg(token_arg.clone())
-                .arg(mpr_url_arg.clone())
-        )
-        .subcommand(
-            Command::new("install")
-            .about("Install packages from APT and the MPR")
-            .arg(
-                Arg::new("pkg")
-                .help("The package(s) to install")
-                .multiple_values(true)
-                .required(true)
-            )
-            .arg(mpr_url_arg.clone())
-        )
-        .subcommand(
-            Command::new("list")
-            .about("List packages available via APT and the MPR")
-            .arg(
-                Arg::new("pkg")
-                .help("The package(s) to get information for")
-                .multiple_values(true)
-            )
-            .arg(mpr_only_arg.clone())
-            .arg(apt_only_arg.clone())
-            .arg(installed_only_arg.clone())
-            .arg(name_only_arg.clone())
-        )
-        .subcommand(
-            Command::new("list-comments")
-                .arg_required_else_help(true)
-                .about("List the comments on a package")
-                .arg(
-                    Arg::new("pkg")
-                        .help("The package to view comments for")
-                        .required(true)
-                )
-                .arg(
-                    Arg::new("paging")
-                        .help("When to send output to a pager")
-                        .long("paging")
-                        .takes_value(true)
-                        .default_value("auto")
-                        .value_parser([
-                            PossibleValue::new("auto"),
-                            PossibleValue::new("always"),
-                            PossibleValue::new("never")
-                        ])
-                )
-                .arg(mpr_url_arg.clone())
-        )
-        .subcommand(
-            Command::new("remove")
-                .about("Remove packages from the system")
-                .arg_required_else_help(true)
-                .arg(
-                    Arg::new("pkg")
-                        .help("The package(s) to remove")
-                        .multiple_values(true)
-                )
-                .arg(
-                    Arg::new("purge")
-                        .help("Remove configuration files along with the package(s)")
-                        .long("purge")
-                )
-                .arg(
-                    Arg::new("autoremove")
-                        .help("Automatically remove any unneeded packages")
-                        .long("autoremove")
-                )
-                .arg(mpr_url_arg.clone().hide(true))
-        )
-        .subcommand(
-            Command::new("search")
-                .about("Search for an APT/MPR package")
-                .arg_required_else_help(true)
-                .arg(
-                    Arg::new("query")
-                        .required(true)
-                        .help("The query to search for")
-                        .multiple_values(true)
-                )
-                .arg(mpr_only_arg.clone())
-                .arg(apt_only_arg.clone())
-                .arg(installed_only_arg.clone())
-                .arg(name_only_arg.clone())
-        )
-        .subcommand(
-            Command::new("update")
-                .about("Update the APT cache on the system")
-                .arg(mpr_url_arg.clone())
-        )
-        .subcommand(
-            Command::new("upgrade")
-                .about("Upgrade the packages on the system")
-                .arg(Arg::new("apt-only").help("Only upgrade APT packages").long("apt-only").conflicts_with("mpr-only"))
-                .arg(Arg::new("mpr-only").help("Only upgrade MPR packages").long("mpr-only").conflicts_with("apt-only"))
-                .arg(mpr_url_arg.clone())
-        )
-        .subcommand(
-            Command::new("whoami")
-                .about("Show the currently authenticated user")
-                .arg(token_arg.clone())
-                .arg(mpr_url_arg.clone())
-        )
-}
-
 #[quit::main]
 fn main() {
-    let cmd_results = get_cli().get_matches();
+    use clap::Parser;
+    let cmd_results = cli::Cli::parse();
 
     // Make sure that this executable has the `setuid` flag set and is owned by
     // root. Parts of this program (intentionally) expect such behavior.
@@ -210,11 +38,11 @@ fn main() {
         if cmd.contains('/') {
             cmd
         } else {
-            which(cmd).unwrap().into_os_string().into_string().unwrap()
+            which(&cmd).unwrap().into_os_string().into_string().unwrap()
         }
     };
 
-    let cmd_metadata = File::open(cmd_name).unwrap().metadata().unwrap();
+    let cmd_metadata = File::open(&cmd_name).unwrap().metadata().unwrap();
 
     // Make sure `root` owns the executable.
     if cmd_metadata.st_uid() != 0 {
@@ -239,13 +67,16 @@ fn main() {
 
     util::sudo::to_root();
 
+    use cli::CliSubcommand::*;
+
     // If we're running a command that should be permission-checked, then do so.
-    if vec!["install", "remove", "update", "upgrade"].contains(&cmd_results.subcommand().unwrap().0)
-    {
+    if matches!(
+        cmd_results.subcommand,
+        Install(_) | Remove(_) | Update(_) | Upgrade(_)
+    ) {
         // If we're running a command that invokes 'makedeb', ensure that we're not
         // running as root.
-        if vec!["install", "upgrade"].contains(&cmd_results.subcommand().unwrap().0)
-            && *util::sudo::NORMAL_UID == 0
+        if matches!(cmd_results.subcommand, Install(_) | Upgrade(_)) && *util::sudo::NORMAL_UID == 0
         {
             message::error(&format!(
             "This command cannot be ran as root, as it needs to call '{}', which is required to run under a non-root user.\n",
@@ -257,17 +88,18 @@ fn main() {
         util::sudo::check_perms();
     }
 
-    match cmd_results.subcommand() {
-        Some(("clone", args)) => clone::clone(args),
-        Some(("comment", args)) => comment::comment(args),
-        Some(("install", args)) => install::install(args),
-        Some(("list", args)) => list::list(args),
-        Some(("list-comments", args)) => list_comments::list_comments(args),
-        Some(("remove", args)) => remove::remove(args),
-        Some(("search", args)) => search::search(args),
-        Some(("update", args)) => update::update(args),
-        Some(("upgrade", args)) => upgrade::upgrade(args),
-        Some(("whoami", args)) => whoami::whoami(args),
-        _ => unreachable!(),
+    match &cmd_results.subcommand {
+        Clone(clone_args) => clone::clone(&cmd_results, clone_args),
+        Comment(comment_args) => comment::comment(&cmd_results, comment_args),
+        Install(install_args) => install::install(&cmd_results, install_args),
+        List(list_args) => list::list(&cmd_results, list_args),
+        ListComments(list_comments_args) => {
+            list_comments::list_comments(&cmd_results, list_comments_args)
+        }
+        Remove(remove_args) => remove::remove(&cmd_results, remove_args),
+        Search(search_args) => search::search(&cmd_results, search_args),
+        Update(update_args) => update::update(&cmd_results, update_args),
+        Upgrade(upgrade_args) => upgrade::upgrade(&cmd_results, upgrade_args),
+        Whoami(whoami_args) => whoami::whoami(&cmd_results, whoami_args),
     };
 }

--- a/src/remove.rs
+++ b/src/remove.rs
@@ -1,21 +1,16 @@
 use crate::{
     apt_util,
     cache::{Cache, MprCache},
+    cli::{Cli, CliRemove},
     message, util,
 };
 use rust_apt::cache::{Cache as AptCache, PackageSort};
 
-pub fn remove(args: &clap::ArgMatches) {
-    let pkglist: Vec<&String> = {
-        if let Some(pkglist) = args.get_many("pkg") {
-            pkglist.collect()
-        } else {
-            Vec::new()
-        }
-    };
-    let purge = args.is_present("purge");
-    let autoremove = args.is_present("autoremove");
-    let mpr_url: &String = args.get_one("mpr-url").unwrap();
+pub fn remove(args: &Cli, cmd_args: &CliRemove) {
+    let pkglist = &cmd_args.pkg;
+    let purge = cmd_args.purge;
+    let autoremove = cmd_args.autoremove;
+    let mpr_url = &args.mpr_url;
     let cache = Cache::new(AptCache::new(), MprCache::new());
 
     // Lock the cache.

--- a/src/search.rs
+++ b/src/search.rs
@@ -1,15 +1,16 @@
 use crate::{
     cache::{Cache, MprCache},
+    cli::{Cli, CliSearch},
     style,
 };
 use rust_apt::cache::{Cache as AptCache, PackageSort};
 
-pub fn search(args: &clap::ArgMatches) {
-    let query_list: Vec<&String> = args.get_many("query").unwrap().collect();
-    let apt_only = args.is_present("apt-only");
-    let mpr_only = args.is_present("mpr-only");
-    let installed_only = args.is_present("installed-only");
-    let name_only = args.is_present("name-only");
+pub fn search(args: &Cli, cmd_args: &CliSearch) {
+    let query_list = &cmd_args.query;
+    let apt_only = args.apt_only;
+    let mpr_only = args.mpr_only;
+    let installed_only = args.installed_only;
+    let name_only = args.name_only;
 
     let cache = Cache::new(AptCache::new(), MprCache::new());
     let mut candidates = Vec::new();

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,4 +1,11 @@
-use crate::{cache::MprCache, message, progress::MistAcquireProgress, style::Colorize, util};
+use crate::{
+    cache::MprCache,
+    cli::{Cli, CliUpdate},
+    message,
+    progress::MistAcquireProgress,
+    style::Colorize,
+    util,
+};
 use makedeb_srcinfo::SplitDependency;
 use rust_apt::{cache::Cache as AptCache, progress::AcquireProgress, tagfile::TagSection};
 use std::{
@@ -8,8 +15,8 @@ use std::{
     process::Command,
 };
 
-pub fn update(args: &clap::ArgMatches) {
-    let mpr_url: &String = args.get_one("mpr-url").unwrap();
+pub fn update(args: &Cli, _cmd_args: &CliUpdate) {
+    let mpr_url = &args.mpr_url;
 
     // For some reason we have to set our current UID to 0 instead of just the EUID
     // when using setuid functionality. TODO: No clue why, but this fixes the

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -1,5 +1,6 @@
 use crate::{
     cache::{Cache, MprCache},
+    cli::{Cli, CliUpgrade},
     install_util, util,
 };
 use rust_apt::{
@@ -8,10 +9,10 @@ use rust_apt::{
 };
 use std::{collections::HashMap, fs};
 
-pub fn upgrade(args: &clap::ArgMatches) {
-    let apt_only = args.is_present("apt-only");
-    let mpr_only = args.is_present("mpr-only");
-    let mpr_url: &String = args.get_one("mpr-url").unwrap();
+pub fn upgrade(args: &Cli, _cmd_args: &CliUpgrade) {
+    let apt_only = args.apt_only;
+    let mpr_only = args.mpr_only;
+    let mpr_url = &args.mpr_url;
 
     let cache = Cache::new(AptCache::new(), MprCache::new());
 

--- a/src/whoami.rs
+++ b/src/whoami.rs
@@ -1,4 +1,7 @@
-use crate::{message, util};
+use crate::{
+    cli::{Cli, CliWhoami},
+    message, util,
+};
 use serde::Deserialize;
 
 #[derive(Deserialize)]
@@ -6,15 +9,15 @@ struct Authenticated {
     user: String,
 }
 
-pub fn whoami(args: &clap::ArgMatches) {
-    let api_token: &String = match args.get_one("token") {
-        Some(token) => token,
+pub fn whoami(args: &Cli, _cmd_args: &CliWhoami) {
+    let api_token = match args.token {
+        Some(ref token) => token,
         None => {
             message::error("No API key was provided.");
             quit::with_code(exitcode::USAGE);
         }
     };
-    let mpr_url: &String = args.get_one("mpr-url").unwrap();
+    let mpr_url = &args.mpr_url;
 
     let request = util::AuthenticatedRequest::new(api_token, mpr_url);
     let resp_text = request.get("test");


### PR DESCRIPTION
This PR takes advantage of more statically known type safety for CLI argument parsing, making use of clap's derive feature. I prefer this over so-called "stringly-typed" code, as less runtime checks have to be performed: i.e., there are notably less `.unwrap()`'s and `if`-guards for things that clap can check for automatically.